### PR TITLE
Add sales tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { RecipeFormPage } from './pages/RecipeFormPage';
 import { GeladinhosPage } from './pages/GeladinhosPage';
 import { GeladinhoFormPage } from './pages/GeladinhoFormPage';
 import { ReportsPage } from './pages/ReportsPage';
+import { SalesPage } from './pages/SalesPage';
+import { SaleFormPage } from './pages/SaleFormPage';
 
 function App() {
   return (
@@ -28,7 +30,10 @@ function App() {
           <Route path="/geladinhos" element={<GeladinhosPage />} />
           <Route path="/geladinhos/novo" element={<GeladinhoFormPage />} />
           <Route path="/geladinhos/editar/:id" element={<GeladinhoFormPage />} />
-          
+
+          <Route path="/vendas" element={<SalesPage />} />
+          <Route path="/vendas/nova" element={<SaleFormPage />} />
+
           <Route path="/relatorios" element={<ReportsPage />} />
           
           <Route path="*" element={<Navigate to="/\" replace />} />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -5,8 +5,9 @@ import {
   Home, 
   PackageOpen, 
   Clipboard, 
-  IceCream2, 
-  BarChart3, 
+  IceCream2,
+  ShoppingCart,
+  BarChart3,
   Menu, 
   X,
   Settings,
@@ -52,6 +53,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
     { to: '/produtos', label: 'Produtos', icon: <PackageOpen size={20} /> },
     { to: '/receitas', label: 'Receitas', icon: <Clipboard size={20} /> },
     { to: '/geladinhos', label: 'Geladinhos', icon: <IceCream2 size={20} /> },
+    { to: '/vendas', label: 'Vendas', icon: <ShoppingCart size={20} /> },
     { to: '/relatorios', label: 'Relatórios', icon: <BarChart3 size={20} /> },
   ];
 

--- a/src/components/sales/SaleForm.tsx
+++ b/src/components/sales/SaleForm.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { useStore } from '../../store';
+import { Input } from '../ui/Input';
+import { Select } from '../ui/Select';
+import { Button } from '../ui/Button';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '../ui/Card';
+import { Sale } from '../../types';
+import { Calendar, IceCream2, Hash, Save } from 'lucide-react';
+
+export interface SaleFormData {
+  sale_date: string;
+  geladinho_id: string;
+  quantity: number;
+  unit_price: number;
+}
+
+interface SaleFormProps {
+  onSubmit: (data: SaleFormData) => void;
+  defaultValues?: Partial<Sale>;
+  isEditing?: boolean;
+}
+
+export const SaleForm: React.FC<SaleFormProps> = ({ onSubmit, defaultValues, isEditing = false }) => {
+  const { geladinhos } = useStore();
+
+  const {
+    register,
+    watch,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SaleFormData>({
+    defaultValues: {
+      sale_date: defaultValues?.sale_date || new Date().toISOString().slice(0, 10),
+      geladinho_id: defaultValues?.geladinho_id || (geladinhos[0]?.id || ''),
+      quantity: defaultValues?.quantity || 1,
+      unit_price: defaultValues?.unit_price || 0,
+    },
+  });
+
+  const watchedQuantity = watch('quantity');
+  const watchedUnit = watch('unit_price');
+  const total = watchedQuantity * watchedUnit;
+
+  const geladinhoOptions = geladinhos.map(g => ({ value: g.id, label: g.name }));
+
+  const onFormSubmit = (data: SaleFormData) => {
+    const formatted = {
+      ...data,
+      quantity: Number(data.quantity),
+      unit_price: Number(data.unit_price),
+      total_price: Number(data.quantity) * Number(data.unit_price),
+    };
+    onSubmit(formatted);
+  };
+
+  return (
+    <Card className="max-w-xl mx-auto animate-fade-in">
+      <form onSubmit={handleSubmit(onFormSubmit)}>
+        <CardHeader>
+          <CardTitle>{isEditing ? 'Editar Venda' : 'Nova Venda'}</CardTitle>
+          <CardDescription>Registre a venda de geladinhos.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            label="Data da Venda"
+            type="date"
+            leftIcon={<Calendar size={18} />}
+            {...register('sale_date', { required: 'Data é obrigatória' })}
+            error={errors.sale_date?.message}
+          />
+          <Select
+            label="Geladinho"
+            options={geladinhoOptions}
+            leftIcon={<IceCream2 size={18} />}
+            {...register('geladinho_id', { required: 'Produto é obrigatório' })}
+            error={errors.geladinho_id?.message}
+          />
+          <div className="grid grid-cols-2 gap-4">
+            <Input
+              label="Quantidade"
+              type="number"
+              min="1"
+              leftIcon={<Hash size={18} />}
+              {...register('quantity', { required: true, valueAsNumber: true, min: 1 })}
+              error={errors.quantity?.message}
+            />
+            <Input
+              label="Preço Unitário"
+              type="number"
+              step="0.01"
+              min="0"
+              leftIcon={<Save size={18} />}
+              {...register('unit_price', { required: true, valueAsNumber: true, min: 0 })}
+              error={errors.unit_price?.message}
+            />
+          </div>
+          <p className="text-sm text-gray-700">Total: R$ {total.toFixed(2)}</p>
+        </CardContent>
+        <CardFooter className="flex justify-end">
+          <Button type="submit" isLoading={isSubmitting} leftIcon={<Save size={18} />}>Salvar Venda</Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+};

--- a/src/components/sales/SaleList.tsx
+++ b/src/components/sales/SaleList.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Sale } from '../../types';
+import { formatCurrency } from '../../utils/calculations';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Plus, Search, ShoppingCart } from 'lucide-react';
+
+interface SaleListProps {
+  sales: Sale[];
+}
+
+export const SaleList: React.FC<SaleListProps> = ({ sales }) => {
+  const [search, setSearch] = useState('');
+  const filtered = sales.filter((s) =>
+    s.geladinho?.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
+        <div className="flex-1 w-full">
+          <Input
+            placeholder="Buscar venda..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            leftIcon={<Search size={18} />}
+          />
+        </div>
+        <Link to="/vendas/nova">
+          <Button leftIcon={<Plus size={18} />}>Nova Venda</Button>
+        </Link>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 bg-white rounded-lg shadow-sm border border-gray-100">
+          <ShoppingCart className="mx-auto h-12 w-12 text-gray-400" />
+          <h3 className="mt-2 text-sm font-medium text-gray-900">Nenhuma venda registrada</h3>
+          <p className="mt-1 text-sm text-gray-500">Adicione suas vendas para acompanhar o desempenho.</p>
+        </div>
+      ) : (
+        <div className="bg-white overflow-hidden shadow-sm rounded-lg border border-gray-200">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Data</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Produto</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Qtd.</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Preço Unit.</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Total</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {filtered.map((sale) => (
+                  <tr key={sale.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {new Date(sale.sale_date).toLocaleDateString('pt-BR')}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                      {sale.geladinho?.name || 'Produto'}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{sale.quantity}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatCurrency(sale.unit_price)}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900">{formatCurrency(sale.total_price)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -12,7 +12,7 @@ import { Download, FileBarChart } from 'lucide-react';
 import { formatCurrency } from '../utils/calculations';
 
 export const ReportsPage: React.FC = () => {
-  const { products, recipes, geladinhos } = useStore();
+  const { products, recipes, geladinhos, monthlySales } = useStore();
   
   const handleExportPricing = () => {
     const activeGeladinhos = geladinhos.filter(g => g.status === 'Ativo');
@@ -142,31 +142,66 @@ export const ReportsPage: React.FC = () => {
           </CardContent>
         </Card>
         
-        <Card>
-          <CardHeader>
-            <CardTitle>Receitas Detalhadas</CardTitle>
-            <CardDescription>
-              Relatório detalhado de todas as receitas e seus ingredientes.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              <div className="flex justify-between items-center text-sm">
-                <span>Total de receitas:</span>
-                <span className="font-medium">{recipes.length}</span>
-              </div>
-              
-              <Button 
-                onClick={handleExportRecipes}
-                leftIcon={<Download size={18} />}
-                fullWidth
-                disabled={recipes.length === 0}
-              >
-                Exportar CSV
-              </Button>
+      <Card>
+        <CardHeader>
+          <CardTitle>Receitas Detalhadas</CardTitle>
+          <CardDescription>
+            Relatório detalhado de todas as receitas e seus ingredientes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <div className="flex justify-between items-center text-sm">
+              <span>Total de receitas:</span>
+              <span className="font-medium">{recipes.length}</span>
             </div>
-          </CardContent>
-        </Card>
+
+            <Button
+              onClick={handleExportRecipes}
+              leftIcon={<Download size={18} />}
+              fullWidth
+              disabled={recipes.length === 0}
+            >
+              Exportar CSV
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Vendas Mensais</CardTitle>
+          <CardDescription>Resumo consolidado das vendas registradas.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {monthlySales.length === 0 ? (
+            <p className="text-sm text-gray-500">Nenhuma venda registrada.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Mês</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Total de Vendas</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {monthlySales.map((ms) => (
+                    <tr key={ms.month}>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {new Date(ms.month).toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' })}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900">
+                        {formatCurrency(ms.total_sales)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
       </div>
       
       <div className="mt-8">

--- a/src/pages/SaleFormPage.tsx
+++ b/src/pages/SaleFormPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useStore } from '../store';
+import { SaleForm, SaleFormData } from '../components/sales/SaleForm';
+import { Button } from '../components/ui/Button';
+import { ArrowLeft } from 'lucide-react';
+
+export const SaleFormPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { addSale } = useStore();
+
+  const handleSubmit = (data: SaleFormData) => {
+    addSale({
+      sale_date: data.sale_date,
+      geladinho_id: data.geladinho_id,
+      quantity: data.quantity,
+      unit_price: data.unit_price,
+      total_price: data.quantity * data.unit_price,
+    });
+    navigate('/vendas');
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center mb-6">
+        <Button
+          variant="ghost"
+          onClick={() => navigate('/vendas')}
+          className="mr-4"
+          leftIcon={<ArrowLeft size={16} />}
+        >
+          Voltar
+        </Button>
+        <h1 className="text-2xl font-bold text-gray-900">Registrar Venda</h1>
+      </div>
+
+      <SaleForm onSubmit={handleSubmit} />
+    </div>
+  );
+};

--- a/src/pages/SalesPage.tsx
+++ b/src/pages/SalesPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useStore } from '../store';
+import { SaleList } from '../components/sales/SaleList';
+
+export const SalesPage: React.FC = () => {
+  const { sales } = useStore();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold text-gray-900">Vendas</h1>
+      </div>
+
+      <SaleList sales={sales} />
+    </div>
+  );
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,3 +68,20 @@ export interface GeladinhoWithCalculations extends Geladinho {
   unit_profit: number;
   real_margin: number;
 }
+
+export interface Sale {
+  id: string;
+  sale_date: string;
+  geladinho_id: string;
+  quantity: number;
+  unit_price: number;
+  total_price: number;
+  created_at: string;
+  updated_at: string;
+  geladinho?: GeladinhoWithCalculations;
+}
+
+export interface MonthlySales {
+  month: string;
+  total_sales: number;
+}

--- a/supabase/migrations/20250604213355_chilly_wave.sql
+++ b/supabase/migrations/20250604213355_chilly_wave.sql
@@ -1,0 +1,43 @@
+/*
+  # Add sales table and monthly sales view
+
+  1. New table: sales
+     - Records each sale with date, product sold, quantity and price
+  2. View: monthly_sales
+     - Aggregates total sales per month
+*/
+
+CREATE TABLE IF NOT EXISTS sales (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sale_date date NOT NULL,
+  geladinho_id uuid NOT NULL REFERENCES geladinhos(id) ON DELETE RESTRICT,
+  quantity integer NOT NULL CHECK (quantity > 0),
+  unit_price numeric NOT NULL CHECK (unit_price >= 0),
+  total_price numeric NOT NULL CHECK (total_price >= 0),
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Enable row level security and generic policy
+ALTER TABLE sales ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage their own sales" ON sales
+  FOR ALL TO authenticated USING (true) WITH CHECK (true);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_sales_sale_date ON sales(sale_date);
+CREATE INDEX IF NOT EXISTS idx_sales_geladinho_id ON sales(geladinho_id);
+
+-- Trigger to update timestamp
+CREATE TRIGGER update_sales_updated_at
+  BEFORE UPDATE ON sales
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- Monthly sales view
+CREATE OR REPLACE VIEW monthly_sales AS
+SELECT
+  date_trunc('month', sale_date)::date AS month,
+  SUM(total_price) AS total_sales
+FROM sales
+GROUP BY month
+ORDER BY month;


### PR DESCRIPTION
## Summary
- add SQL migration for sales table and monthly sales view
- support sales and monthlySales in store
- add sale types
- add SaleForm, SaleList, SalesPage and SaleFormPage
- link sales in navigation
- show monthly sales table in reports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840ba5bdea08330b4e3a0c989fc40ff