### PR TITLE
fix icon overlap in forms

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -46,10 +46,10 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             ref={ref}
             className={twMerge(
               'block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm transition-colors',
+              'border py-2 px-3',
               error && 'border-error-500 focus:border-error-500 focus:ring-error-500',
               leftIcon && 'pl-10',
               rightIcon && 'pr-10',
-              'border py-2 px-3',
               className
             )}
             {...props}


### PR DESCRIPTION
## Summary
- make left/right icon padding override default field padding

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840d8d757d883309e606346511dd97e