### PR TITLE
Add PWA basic setup

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,11 @@
 {
- "name": "App",
- "icons": [
+  "name": "Dolce Nuve Sistema",
+  "short_name": "DolceNuve",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
   {
    "src": "\/android-icon-36x36.png",
    "sizes": "36x36",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,37 @@
+const CACHE_NAME = 'dolce-nuve-cache-v1';
+const APP_STATIC = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/favicon.ico'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(APP_STATIC))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        const responseClone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone));
+        return response;
+      });
+    }).catch(() => caches.match('/'))
+  );
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,12 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- add web app manifest metadata
- register a service worker in the React entry point
- include a basic service worker for caching

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419bce0b84833087441241507e17d4