### PR TITLE
Fix duplicate sales trigger creation in migrations

### DIFF
--- a/supabase/migrations/20250604214746_scarlet_dew.sql
+++ b/supabase/migrations/20250604214746_scarlet_dew.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS public.sales (
 );
 
 -- Create trigger for updated_at
+DROP TRIGGER IF EXISTS update_sales_updated_at ON public.sales;
 CREATE TRIGGER update_sales_updated_at
     BEFORE UPDATE ON public.sales
     FOR EACH ROW

--- a/supabase/migrations/20250604220811_royal_wave.sql
+++ b/supabase/migrations/20250604220811_royal_wave.sql
@@ -102,6 +102,8 @@ BEGIN
 END;
 $$ language 'plpgsql';
 
+DROP TRIGGER IF EXISTS update_sales_updated_at ON sales;
+
 CREATE TRIGGER update_sales_updated_at
   BEFORE UPDATE ON sales
   FOR EACH ROW

--- a/supabase/migrations/20250604220937_turquoise_lake.sql
+++ b/supabase/migrations/20250604220937_turquoise_lake.sql
@@ -87,6 +87,8 @@ BEGIN
 END;
 $$ language 'plpgsql';
 
+DROP TRIGGER IF EXISTS update_sales_updated_at ON sales;
+
 CREATE TRIGGER update_sales_updated_at
   BEFORE UPDATE ON sales
   FOR EACH ROW

--- a/supabase/migrations/20250604221039_broken_mountain.sql
+++ b/supabase/migrations/20250604221039_broken_mountain.sql
@@ -64,6 +64,7 @@ CREATE POLICY "Users can delete their own sales"
   USING (true);
 
 -- Create updated_at trigger
+DROP TRIGGER IF EXISTS update_sales_updated_at ON sales;
 CREATE TRIGGER update_sales_updated_at
   BEFORE UPDATE ON sales
   FOR EACH ROW

--- a/supabase/migrations/20250605224720_muddy_peak.sql
+++ b/supabase/migrations/20250605224720_muddy_peak.sql
@@ -138,6 +138,7 @@ CREATE TRIGGER update_geladinho_stock_updated_at
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_sales_updated_at ON sales;
 CREATE TRIGGER update_sales_updated_at
   BEFORE UPDATE ON sales
   FOR EACH ROW


### PR DESCRIPTION
## Summary
- ensure migrations drop existing `update_sales_updated_at` before creating trigger

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68421ed5d87c8330bcb67c6273355fcc