### PR TITLE
Fix unit_measure migration errors

### DIFF
--- a/supabase/migrations/20250604023113_white_truth.sql
+++ b/supabase/migrations/20250604023113_white_truth.sql
@@ -24,9 +24,9 @@
     - `movement_type`: Types of inventory movements
 */
 
--- Create enum types
-CREATE TYPE unit_measure AS ENUM ('gramas', 'litros', 'unidades');
-CREATE TYPE movement_type AS ENUM ('entrada', 'saida', 'ajuste');
+-- Use IF NOT EXISTS to make the migration idempotent
+CREATE TYPE IF NOT EXISTS unit_measure AS ENUM ('gramas', 'litros', 'unidades');
+CREATE TYPE IF NOT EXISTS movement_type AS ENUM ('entrada', 'saida', 'ajuste');
 
 -- Create products table
 CREATE TABLE IF NOT EXISTS products (

--- a/supabase/migrations/20250604225627_fading_grove.sql
+++ b/supabase/migrations/20250604225627_fading_grove.sql
@@ -1,10 +1,10 @@
 /*
   # Update unit measure to only use grams
-  
+
   1. Changes
     - Modify unit_measure type to only allow 'gramas'
     - Update existing records to use 'gramas'
-    
+
   2. Data Migration
     - Convert existing measurements to grams
     - litros -> grams (multiply by 1000)
@@ -12,26 +12,43 @@
 */
 
 -- First create a backup of the current data
-CREATE TABLE products_backup AS SELECT * FROM products;
+CREATE TABLE IF NOT EXISTS products_backup AS SELECT * FROM products;
 
 -- Update the unit_measure type
-ALTER TYPE unit_measure RENAME TO unit_measure_old;
-CREATE TYPE unit_measure AS ENUM ('gramas');
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'unit_measure') THEN
+    ALTER TYPE unit_measure RENAME TO unit_measure_old;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'unit_measure') THEN
+    CREATE TYPE unit_measure AS ENUM ('gramas');
+  END IF;
+END $$;
 
 -- Convert existing data
 UPDATE products
-SET 
-  unit_of_measure = 'gramas'::unit_measure,
-  total_quantity = CASE 
+SET
+  unit_of_measure = 'gramas',
+  total_quantity = CASE
     WHEN unit_of_measure = 'litros' THEN total_quantity * 1000
     ELSE total_quantity
   END
 WHERE unit_of_measure != 'gramas';
 
--- Drop old type
-DROP TYPE unit_measure_old;
-
--- Add constraint to ensure only grams are used
-ALTER TABLE products 
+-- Change column to use the new type
+ALTER TABLE products
+  ALTER COLUMN unit_of_measure TYPE unit_measure USING unit_of_measure::text::unit_measure,
   ALTER COLUMN unit_of_measure SET DEFAULT 'gramas',
   ALTER COLUMN unit_of_measure SET NOT NULL;
+
+-- Drop old type if it exists
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'unit_measure_old') THEN
+    DROP TYPE unit_measure_old;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- make initial enum creation idempotent
- rewrite migration for updating `unit_measure` type

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842446b30d08330a65eb68154412067