### PR TITLE
Fix unit_measure migration errors

### DIFF
--- a/supabase/migrations/20250604023113_white_truth.sql
+++ b/supabase/migrations/20250604023113_white_truth.sql
@@ -24,9 +24,9 @@
     - `movement_type`: Types of inventory movements
 */
 
--- Create enum types
-CREATE TYPE unit_measure AS ENUM ('gramas', 'litros', 'unidades');
-CREATE TYPE movement_type AS ENUM ('entrada', 'saida', 'ajuste');
+-- Use IF NOT EXISTS to make the migration idempotent
+CREATE TYPE IF NOT EXISTS unit_measure AS ENUM ('gramas', 'litros', 'unidades');
+CREATE TYPE IF NOT EXISTS movement_type AS ENUM ('entrada', 'saida', 'ajuste');
 
 -- Create products table
 CREATE TABLE IF NOT EXISTS products (
@@ -84,6 +84,14 @@ ALTER TABLE recipe_ingredients ENABLE ROW LEVEL SECURITY;
 ALTER TABLE geladinhos ENABLE ROW LEVEL SECURITY;
 
 -- Create policies
+DO $$
+BEGIN
+  DROP POLICY IF EXISTS "Users can read their own products" ON products;
+  DROP POLICY IF EXISTS "Users can insert their own products" ON products;
+  DROP POLICY IF EXISTS "Users can update their own products" ON products;
+  DROP POLICY IF EXISTS "Users can delete their own products" ON products;
+END $$;
+
 CREATE POLICY "Users can read their own products"
   ON products
   FOR SELECT
@@ -110,6 +118,14 @@ CREATE POLICY "Users can delete their own products"
   USING (true);
 
 -- Recipe policies
+DO $$
+BEGIN
+  DROP POLICY IF EXISTS "Users can read their own recipes" ON recipes;
+  DROP POLICY IF EXISTS "Users can insert their own recipes" ON recipes;
+  DROP POLICY IF EXISTS "Users can update their own recipes" ON recipes;
+  DROP POLICY IF EXISTS "Users can delete their own recipes" ON recipes;
+END $$;
+
 CREATE POLICY "Users can read their own recipes"
   ON recipes
   FOR SELECT
@@ -136,6 +152,14 @@ CREATE POLICY "Users can delete their own recipes"
   USING (true);
 
 -- Recipe ingredients policies
+DO $$
+BEGIN
+  DROP POLICY IF EXISTS "Users can read their own recipe ingredients" ON recipe_ingredients;
+  DROP POLICY IF EXISTS "Users can insert their own recipe ingredients" ON recipe_ingredients;
+  DROP POLICY IF EXISTS "Users can update their own recipe ingredients" ON recipe_ingredients;
+  DROP POLICY IF EXISTS "Users can delete their own recipe ingredients" ON recipe_ingredients;
+END $$;
+
 CREATE POLICY "Users can read their own recipe ingredients"
   ON recipe_ingredients
   FOR SELECT
@@ -162,6 +186,14 @@ CREATE POLICY "Users can delete their own recipe ingredients"
   USING (true);
 
 -- Geladinho policies
+DO $$
+BEGIN
+  DROP POLICY IF EXISTS "Users can read their own geladinhos" ON geladinhos;
+  DROP POLICY IF EXISTS "Users can insert their own geladinhos" ON geladinhos;
+  DROP POLICY IF EXISTS "Users can update their own geladinhos" ON geladinhos;
+  DROP POLICY IF EXISTS "Users can delete their own geladinhos" ON geladinhos;
+END $$;
+
 CREATE POLICY "Users can read their own geladinhos"
   ON geladinhos
   FOR SELECT
@@ -205,21 +237,25 @@ END;
 $$ language 'plpgsql';
 
 -- Create triggers to automatically update updated_at
+DROP TRIGGER IF EXISTS update_products_updated_at ON products;
 CREATE TRIGGER update_products_updated_at
   BEFORE UPDATE ON products
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_recipes_updated_at ON recipes;
 CREATE TRIGGER update_recipes_updated_at
   BEFORE UPDATE ON recipes
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_recipe_ingredients_updated_at ON recipe_ingredients;
 CREATE TRIGGER update_recipe_ingredients_updated_at
   BEFORE UPDATE ON recipe_ingredients
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_geladinhos_updated_at ON geladinhos;
 CREATE TRIGGER update_geladinhos_updated_at
   BEFORE UPDATE ON geladinhos
   FOR EACH ROW

--- a/supabase/migrations/20250604023520_silent_mode.sql
+++ b/supabase/migrations/20250604023520_silent_mode.sql
@@ -71,6 +71,15 @@ ALTER TABLE recipes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE recipe_ingredients ENABLE ROW LEVEL SECURITY;
 ALTER TABLE geladinhos ENABLE ROW LEVEL SECURITY;
 
+-- Drop existing product policies if they exist
+DO $$
+BEGIN
+  DROP POLICY IF EXISTS "Users can read their own products" ON products;
+  DROP POLICY IF EXISTS "Users can insert their own products" ON products;
+  DROP POLICY IF EXISTS "Users can update their own products" ON products;
+  DROP POLICY IF EXISTS "Users can delete their own products" ON products;
+END $$;
+
 -- Create policies
 CREATE POLICY "Users can read their own products"
   ON products
@@ -98,6 +107,14 @@ CREATE POLICY "Users can delete their own products"
   USING (true);
 
 -- Recipe policies
+DO $$
+BEGIN
+  DROP POLICY IF EXISTS "Users can read their own recipes" ON recipes;
+  DROP POLICY IF EXISTS "Users can insert their own recipes" ON recipes;
+  DROP POLICY IF EXISTS "Users can update their own recipes" ON recipes;
+  DROP POLICY IF EXISTS "Users can delete their own recipes" ON recipes;
+END $$;
+
 CREATE POLICY "Users can read their own recipes"
   ON recipes
   FOR SELECT
@@ -124,6 +141,14 @@ CREATE POLICY "Users can delete their own recipes"
   USING (true);
 
 -- Recipe ingredients policies
+DO $$
+BEGIN
+  DROP POLICY IF EXISTS "Users can read their own recipe ingredients" ON recipe_ingredients;
+  DROP POLICY IF EXISTS "Users can insert their own recipe ingredients" ON recipe_ingredients;
+  DROP POLICY IF EXISTS "Users can update their own recipe ingredients" ON recipe_ingredients;
+  DROP POLICY IF EXISTS "Users can delete their own recipe ingredients" ON recipe_ingredients;
+END $$;
+
 CREATE POLICY "Users can read their own recipe ingredients"
   ON recipe_ingredients
   FOR SELECT
@@ -150,6 +175,14 @@ CREATE POLICY "Users can delete their own recipe ingredients"
   USING (true);
 
 -- Geladinho policies
+DO $$
+BEGIN
+  DROP POLICY IF EXISTS "Users can read their own geladinhos" ON geladinhos;
+  DROP POLICY IF EXISTS "Users can insert their own geladinhos" ON geladinhos;
+  DROP POLICY IF EXISTS "Users can update their own geladinhos" ON geladinhos;
+  DROP POLICY IF EXISTS "Users can delete their own geladinhos" ON geladinhos;
+END $$;
+
 CREATE POLICY "Users can read their own geladinhos"
   ON geladinhos
   FOR SELECT
@@ -193,21 +226,25 @@ END;
 $$ language 'plpgsql';
 
 -- Create triggers to automatically update updated_at
+DROP TRIGGER IF EXISTS update_products_updated_at ON products;
 CREATE TRIGGER update_products_updated_at
   BEFORE UPDATE ON products
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_recipes_updated_at ON recipes;
 CREATE TRIGGER update_recipes_updated_at
   BEFORE UPDATE ON recipes
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_recipe_ingredients_updated_at ON recipe_ingredients;
 CREATE TRIGGER update_recipe_ingredients_updated_at
   BEFORE UPDATE ON recipe_ingredients
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_geladinhos_updated_at ON geladinhos;
 CREATE TRIGGER update_geladinhos_updated_at
   BEFORE UPDATE ON geladinhos
   FOR EACH ROW

--- a/supabase/migrations/20250604032829_round_dream.sql
+++ b/supabase/migrations/20250604032829_round_dream.sql
@@ -29,6 +29,15 @@ BEGIN
   END IF;
 END $$;
 
+-- Drop existing policies if they exist
+DO $$
+BEGIN
+  DROP POLICY IF EXISTS "Users can insert their own products" ON products;
+  DROP POLICY IF EXISTS "Users can read their own products" ON products;
+  DROP POLICY IF EXISTS "Users can update their own products" ON products;
+  DROP POLICY IF EXISTS "Users can delete their own products" ON products;
+END $$;
+
 -- Create policies
 CREATE POLICY "Users can insert their own products"
 ON products

--- a/supabase/migrations/20250604225627_fading_grove.sql
+++ b/supabase/migrations/20250604225627_fading_grove.sql
@@ -1,10 +1,10 @@
 /*
   # Update unit measure to only use grams
-  
+
   1. Changes
     - Modify unit_measure type to only allow 'gramas'
     - Update existing records to use 'gramas'
-    
+
   2. Data Migration
     - Convert existing measurements to grams
     - litros -> grams (multiply by 1000)
@@ -12,26 +12,43 @@
 */
 
 -- First create a backup of the current data
-CREATE TABLE products_backup AS SELECT * FROM products;
+CREATE TABLE IF NOT EXISTS products_backup AS SELECT * FROM products;
 
 -- Update the unit_measure type
-ALTER TYPE unit_measure RENAME TO unit_measure_old;
-CREATE TYPE unit_measure AS ENUM ('gramas');
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'unit_measure') THEN
+    ALTER TYPE unit_measure RENAME TO unit_measure_old;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'unit_measure') THEN
+    CREATE TYPE unit_measure AS ENUM ('gramas');
+  END IF;
+END $$;
 
 -- Convert existing data
 UPDATE products
-SET 
-  unit_of_measure = 'gramas'::unit_measure,
-  total_quantity = CASE 
+SET
+  unit_of_measure = 'gramas',
+  total_quantity = CASE
     WHEN unit_of_measure = 'litros' THEN total_quantity * 1000
     ELSE total_quantity
   END
 WHERE unit_of_measure != 'gramas';
 
--- Drop old type
-DROP TYPE unit_measure_old;
-
--- Add constraint to ensure only grams are used
-ALTER TABLE products 
+-- Change column to use the new type
+ALTER TABLE products
+  ALTER COLUMN unit_of_measure TYPE unit_measure USING unit_of_measure::text::unit_measure,
   ALTER COLUMN unit_of_measure SET DEFAULT 'gramas',
   ALTER COLUMN unit_of_measure SET NOT NULL;
+
+-- Drop old type if it exists
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'unit_measure_old') THEN
+    DROP TYPE unit_measure_old;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- make initial enum creation idempotent
- rewrite migration for updating `unit_measure` type
- handle pre-existing policies and triggers in early migrations

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842446b30d08330a65eb68154412067