### PR TITLE
Padroniza largura dos formulários

### DIFF
--- a/src/components/products/ProductForm.tsx
+++ b/src/components/products/ProductForm.tsx
@@ -45,7 +45,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
   };
 
   return (
-    <Card className="max-w-2xl mx-auto animate-fade-in">
+    <Card className="max-w-3xl mx-auto animate-fade-in">
       <form onSubmit={handleSubmit(onFormSubmit)}>
         <CardHeader>
           <CardTitle>{isEditing ? 'Editar Produto' : 'Novo Produto'}</CardTitle>

--- a/src/components/sales/SaleForm.tsx
+++ b/src/components/sales/SaleForm.tsx
@@ -55,7 +55,7 @@ export const SaleForm: React.FC<SaleFormProps> = ({ onSubmit, defaultValues, isE
   };
 
   return (
-    <Card className="max-w-xl mx-auto animate-fade-in">
+    <Card className="max-w-3xl mx-auto animate-fade-in">
       <form onSubmit={handleSubmit(onFormSubmit)}>
         <CardHeader>
           <CardTitle>{isEditing ? 'Editar Venda' : 'Nova Venda'}</CardTitle>

--- a/src/components/stock/StockAdjustmentForm.tsx
+++ b/src/components/stock/StockAdjustmentForm.tsx
@@ -100,7 +100,7 @@ export const StockAdjustmentForm: React.FC<StockAdjustmentFormProps> = ({
   };
 
   return (
-    <Card className="max-w-2xl mx-auto">
+    <Card className="max-w-3xl mx-auto">
       <form onSubmit={handleSubmit(onFormSubmit)}>
         <CardHeader>
           <CardTitle>Ajuste de Estoque</CardTitle>


### PR DESCRIPTION
## Summary
- fix width of ProductForm to match stock history
- padronize width of StockAdjustmentForm and SaleForm

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843134caaac833086ec01562b1641f4