### PR TITLE
Fix geladinho stock calculation

### DIFF
--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -215,11 +215,10 @@ export const processGeladinhoWithCalculations = (geladinho: Geladinho & { stock?
 
   // Calculate available quantity from stock entries
   const available_quantity = geladinho.stock?.reduce((total, entry) => {
-    if (entry.movement_type === 'entrada') {
-      return total + entry.quantity;
-    } else {
-      return total - entry.quantity;
-    }
+    const qty = Math.abs(entry.quantity);
+    return entry.movement_type === 'entrada'
+      ? total + qty
+      : total - qty;
   }, 0) || 0;
 
   console.log(`Geladinho ${geladinho.name} calculations:`, {


### PR DESCRIPTION
## Summary
- fix stock computation for geladinhos to always use absolute quantity

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68439d50116c8330aa7c090875177ac9