### PR TITLE
Implement net sale view with discounts

### DIFF
--- a/src/components/sales/SaleForm.tsx
+++ b/src/components/sales/SaleForm.tsx
@@ -13,6 +13,7 @@ export interface SaleFormData {
   geladinho_id: string;
   quantity: number;
   unit_price: number;
+  discount: number;
 }
 
 interface SaleFormProps {
@@ -35,13 +36,16 @@ export const SaleForm: React.FC<SaleFormProps> = ({ onSubmit, defaultValues, isE
       geladinho_id: defaultValues?.geladinho_id || (geladinhos[0]?.id || ''),
       quantity: defaultValues?.quantity || 1,
       unit_price: defaultValues?.unit_price || 0,
+      discount: defaultValues?.discount || 0,
     },
   });
 
   const watchedQuantity = watch('quantity');
   const watchedUnit = watch('unit_price');
+  const watchedDiscount = watch('discount');
   const watchedGeladinhoId = watch('geladinho_id');
   const total = watchedQuantity * watchedUnit;
+  const netTotal = total - watchedDiscount;
 
   // Get the selected geladinho and its available quantity
   const selectedGeladinho = geladinhos.find(g => g.id === watchedGeladinhoId);
@@ -54,6 +58,7 @@ export const SaleForm: React.FC<SaleFormProps> = ({ onSubmit, defaultValues, isE
       ...data,
       quantity: Number(data.quantity),
       unit_price: Number(data.unit_price),
+      discount: Number(data.discount) || 0,
       total_price: Number(data.quantity) * Number(data.unit_price),
     };
     onSubmit(formatted);
@@ -113,15 +118,28 @@ export const SaleForm: React.FC<SaleFormProps> = ({ onSubmit, defaultValues, isE
               step="0.01"
               min="0"
               leftIcon={<Save size={18} />}
-              {...register('unit_price', { 
-                required: 'Preço é obrigatório', 
-                valueAsNumber: true, 
+              {...register('unit_price', {
+                required: 'Preço é obrigatório',
+                valueAsNumber: true,
                 min: { value: 0, message: 'Preço deve ser maior ou igual a 0' }
               })}
               error={errors.unit_price?.message}
             />
+            <Input
+              label="Desconto"
+              type="number"
+              step="0.01"
+              min="0"
+              leftIcon={<Save size={18} />}
+              {...register('discount', {
+                valueAsNumber: true,
+                min: { value: 0, message: 'Desconto deve ser maior ou igual a 0' }
+              })}
+              error={errors.discount?.message}
+            />
           </div>
-          <p className="text-sm text-gray-700">Total: R$ {total.toFixed(2)}</p>
+          <p className="text-sm text-gray-700">Total Bruto: R$ {total.toFixed(2)}</p>
+          <p className="text-sm text-gray-700">Total Líquido: R$ {netTotal.toFixed(2)}</p>
         </CardContent>
         <CardFooter className="flex justify-end">
           <Button 

--- a/src/components/sales/SaleList.tsx
+++ b/src/components/sales/SaleList.tsx
@@ -65,7 +65,8 @@ export const SaleList: React.FC<SaleListProps> = ({ sales, onDelete }) => {
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Produto</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Qtd.</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Preço Unit.</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Total</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Bruto</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Líquido</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                 </tr>
               </thead>
@@ -80,7 +81,12 @@ export const SaleList: React.FC<SaleListProps> = ({ sales, onDelete }) => {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{sale.quantity}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatCurrency(sale.unit_price)}</td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900">{formatCurrency(sale.total_price)}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900">
+                      {formatCurrency(sale.total_price)}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900">
+                      {formatCurrency(sale.total_price - (sale.discount || 0))}
+                    </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
                       {onDelete && (
                         <Button

--- a/src/pages/SaleFormPage.tsx
+++ b/src/pages/SaleFormPage.tsx
@@ -15,6 +15,7 @@ export const SaleFormPage: React.FC = () => {
       geladinho_id: data.geladinho_id,
       quantity: data.quantity,
       unit_price: data.unit_price,
+      discount: data.discount,
       total_price: data.quantity * data.unit_price,
     });
     navigate('/vendas');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,6 +100,8 @@ export interface Sale {
   geladinho_id: string;
   quantity: number;
   unit_price: number;
+  /** Desconto aplicado na venda */
+  discount: number;
   total_price: number;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/20250606051000_discount_on_sales.sql
+++ b/supabase/migrations/20250606051000_discount_on_sales.sql
@@ -1,0 +1,19 @@
+/*
+  # Add discount to sales
+
+  1. Changes
+    - Add discount column to sales table with default 0
+    - Update monthly_sales view to subtract discount from total_price
+*/
+
+ALTER TABLE sales
+ADD COLUMN discount numeric NOT NULL DEFAULT 0 CHECK (discount >= 0);
+
+-- Update monthly_sales view
+CREATE OR REPLACE VIEW monthly_sales AS
+SELECT
+  date_trunc('month', sale_date)::date AS month,
+  SUM(total_price - discount) AS total_sales
+FROM sales
+GROUP BY month
+ORDER BY month;


### PR DESCRIPTION
## Summary
- add `discount` field to `Sale` type
- support discount in sale form and page
- display both gross and net totals in sales list
- migration to add `discount` column and update monthly sales view

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a27627e48330b356918c02a3c4da